### PR TITLE
fix: improve validation errors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,11 @@
 import { NestFactory } from '@nestjs/core';
 import helmet from 'helmet';
 import { NestExpressApplication } from '@nestjs/platform-express';
-import { ValidationPipe } from '@nestjs/common';
 
 import { AppModule } from './app.module';
 import { AppConfig } from 'src/modules/configuration/configuration.service';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { ValidationPipe } from './modules/validation.pipe';
 
 import session from 'express-session';
 

--- a/src/modules/validation.pipe.ts
+++ b/src/modules/validation.pipe.ts
@@ -1,0 +1,34 @@
+import { ArgumentMetadata, BadRequestException, Logger, PipeTransform } from '@nestjs/common';
+import { plainToClass } from 'class-transformer';
+import { validate } from 'class-validator';
+
+export class ValidationPipe implements PipeTransform<any> {
+  private logger = new Logger(ValidationPipe.name);
+
+  async transform(value: any, metadata: ArgumentMetadata): Promise<any> {
+    if (!metadata.metatype || !this.toValidate(metadata.metatype)) {
+      return value;
+    }
+
+    const object = plainToClass(metadata.metatype, value);
+    const errors = await validate(object, { validationError: { target: false } });
+
+    if (errors.length > 0) {
+      const error = new BadRequestException({
+        error: 'ValidationFailed',
+        message: 'Validation failed',
+        errors,
+      });
+      this.logger.error(error);
+      throw error;
+    }
+
+    return value;
+  }
+
+  toValidate(metatype: Function) {
+    const types: Function[] = [String, Boolean, Number, Array, Object];
+
+    return !types.includes(metatype);
+  }
+}


### PR DESCRIPTION
All validation errors contain an error, message and detailed errors for each field:

```
{
    "error": "ValidationFailed",
    "message": "Validation failed",
    "errors": [
        {
            "value": "4",
            "property": "numberOfEditions",
            "children": [],
            "constraints": {
                "isNumber": "numberOfEditions must be a number conforming to the specified constraints"
            }
        }
    ]
}
```