### PR TITLE
feat: add creator address to NFTs

### DIFF
--- a/migrations/1632903462826-Nft.ts
+++ b/migrations/1632903462826-Nft.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class Nft1632903462826 implements MigrationInterface {
+    name = 'Nft1632903462826'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "nft" ADD "creator" character varying`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "nft" DROP COLUMN "creator"`);
+    }
+
+}

--- a/src/modules/ethEventsScraper/service_layer/ethEventsScraper.service.ts
+++ b/src/modules/ethEventsScraper/service_layer/ethEventsScraper.service.ts
@@ -159,6 +159,7 @@ export class EthEventsScraperService {
     nft.txHash = event.tx_hash;
     nft.tokenId = event.token_id;
     nft.tokenUri = event.token_uri;
+    nft.creator = event.receiver?.toLowerCase();
   }
 
   private mapTokenUriToEvents(events: MintedNftEvent[]) {

--- a/src/modules/nft/domain/nft.entity.ts
+++ b/src/modules/nft/domain/nft.entity.ts
@@ -34,6 +34,9 @@ export class Nft {
   editionUUID: string;
 
   @Column({ nullable: true })
+  creator: string;
+
+  @Column({ nullable: true })
   name: string;
 
   @Column({ nullable: true })


### PR DESCRIPTION
This PR adds the creator address to the NFT entity. The address can be fetched easily from the Mint event parsed by the scraper