### PR TITLE
fix: separate endpoint to get pending NFTs

### DIFF
--- a/src/modules/nft/entrypoints/dto.ts
+++ b/src/modules/nft/entrypoints/dto.ts
@@ -2,6 +2,7 @@ import {
   ArrayMaxSize,
   ArrayMinSize,
   IsArray,
+  isNumber,
   IsNumber,
   IsNumberString,
   IsObject,
@@ -271,6 +272,15 @@ export class GetNftTokenUriBody {
   })
   @Transform(({ value }) => value && JSON.parse(value))
   royalties?: SaveNftRoyalty[];
+
+  @IsNumber()
+  @ApiProperty({
+    example: 1,
+    description: 'The collection id',
+    required: true,
+  })
+  @Transform(({ value }) => value && parseInt(value))
+  collectionId: number;
 }
 
 export class GetMyNftsResponse {

--- a/src/modules/nft/entrypoints/nft.controller.ts
+++ b/src/modules/nft/entrypoints/nft.controller.ts
@@ -284,6 +284,15 @@ export class NftController {
     return this.nftService.getMyCollectionsPendingPage(req.user.sub);
   }
 
+  @Get('pages/my-nfts/pending')
+  @UseGuards(JwtAuthGuard)
+  @ApiTags('nfts')
+  @ApiOperation({ summary: 'Pending NFTs for My NFTs page' })
+  @ApiBearerAuth()
+  async getMyNftsPendingPage(@Req() req) {
+    return this.nftService.getMyNftsPendingPage(req.user.sub);
+  }
+
   @Get('pages/nft/:collectionAddress/:tokenId')
   @ApiTags('nfts')
   @ApiOperation({ summary: 'Get data for NFT page' })


### PR DESCRIPTION
This PR creates a new endpoint `GET pages/my-nfts/pending` to get NFTs that are in minting state

**BREAKING CHANGE:** 
`POST nfts/token-uri` endpoint requires a new property to be added in the FormData: **collectionId**