### PR TITLE
improve(nft-page): add tokenIds to response

### DIFF
--- a/src/modules/nft/service_layer/nft.service.ts
+++ b/src/modules/nft/service_layer/nft.service.ts
@@ -572,7 +572,7 @@ export class NftService {
   }
 
   public async getUserNfts(username: string) {
-    const user = await this.userRepository.findOne({ where: { universePageUrl: username } });
+    const user = await this.userRepository.findOne({ where: [{ universePageUrl: username }, { address: username }] });
 
     if (!user) {
       throw new UserNotFoundException();


### PR DESCRIPTION
I'm adding tokenIds to the response as we're adding a search bar to the page where the user can select each individual edition. I tried to keep the query as light as possible. Let me know if it can be optimized.

![image](https://user-images.githubusercontent.com/29047760/136224803-3f953fb3-6b51-429e-b472-d94e887acd33.png)
