### PR TITLE
fix(nft-page-tokenids): wrong query

### DIFF
--- a/src/modules/nft/service_layer/nft.service.ts
+++ b/src/modules/nft/service_layer/nft.service.ts
@@ -455,7 +455,7 @@ export class NftService {
         .orderBy('nft.editionUUID')
         .getMany(),
       this.nftRepository.find({
-        where: { collectionId: collection.id },
+        where: { editionUUID: nft.editionUUID },
         select: ['tokenId'],
         order: { tokenId: 'ASC' },
       }),


### PR DESCRIPTION
Fixed query to include nfts only from the specific nft editions