### PR TITLE
improve: add support for MintingNFT multiple transactions

### DIFF
--- a/migrations/1634120805663-MintingNft.ts
+++ b/migrations/1634120805663-MintingNft.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class MintingNft1634120805663 implements MigrationInterface {
+    name = 'MintingNft1634120805663'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "universe-backend"."minting_nft" DROP COLUMN "txHash"`);
+        await queryRunner.query(`ALTER TABLE "universe-backend"."minting_nft" ADD "txHashes" jsonb`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "universe-backend"."minting_nft" DROP COLUMN "txHashes"`);
+        await queryRunner.query(`ALTER TABLE "universe-backend"."minting_nft" ADD "txHash" character varying`);
+    }
+
+}

--- a/src/modules/nft/domain/minting-nft.entity.ts
+++ b/src/modules/nft/domain/minting-nft.entity.ts
@@ -61,8 +61,11 @@ export class MintingNft {
   @Column({ type: 'jsonb', nullable: true })
   royalties?: any;
 
-  @Column({ nullable: true })
-  txHash?: string;
+  // @Column({ nullable: true })
+  // txHash?: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  txHashes?: string[];
 
   @Column({ nullable: true, type: 'character' })
   txStatus?: TxStatus;

--- a/src/modules/nft/entrypoints/cron.service.ts
+++ b/src/modules/nft/entrypoints/cron.service.ts
@@ -20,7 +20,7 @@ export class NftCronService {
     const date = new Date();
     date.setHours(date.getHours() - this.TIME_LIMT);
     const result = await this.mintingNftRepository.delete({
-      txHash: null,
+      txHashes: null,
       createdAt: LessThanOrEqual(date),
     });
     this.logger.log(`deleted ${result.affected} records`);

--- a/src/modules/nft/service_layer/nft.service.ts
+++ b/src/modules/nft/service_layer/nft.service.ts
@@ -422,7 +422,11 @@ export class NftService {
     const mintingNft = await this.mintingNftRepository.findOne({ where: { id, userId } });
     if (!mintingNft) throw new NftNotFoundException();
 
-    mintingNft.txHash = body.txHash;
+    if (Array.isArray(mintingNft.txHashes)) {
+      mintingNft.txHashes = [...mintingNft.txHashes, body.txHash];
+    } else {
+      mintingNft.txHashes = [body.txHash];
+    }
     mintingNft.txStatus = 'pending';
     if (mintingNft.savedNftId) {
       await this.savedNftRepository.delete({ id: mintingNft.savedNftId });


### PR DESCRIPTION
This PR enables MintingNFT entities to hold an array of txHashes, not just one. This is useful for NFTs with a  big number of editions, the process of minting being distributes across multiple transactions