### PR TITLE
Auctions change status endpoint

### DIFF
--- a/src/modules/auction/entrypoints/auction.controller.ts
+++ b/src/modules/auction/entrypoints/auction.controller.ts
@@ -31,6 +31,7 @@ import {
   DeployAuctionBody,
   WithdrawNftsBody,
   DepositNftsBody,
+  ChangeAuctionStatus,
 } from './dto';
 import { AuctionService } from '../service-layer/auction.service';
 import { JwtAuthGuard, OptionalJwtAuthGuard } from '../../auth/jwt-auth.guard';
@@ -302,5 +303,11 @@ export class AuctionController {
   @UseGuards(JwtAuthGuard)
   async getAuction(@Req() req, @Param('id') id = 0) {
     return await this.auctionService.getAuction(id);
+  }
+
+  @Patch('auction/status')
+  @UseGuards(JwtAuthGuard)
+  async changeAuctionStatus(@Req() req, @Body() changeAuctionStatusBody: ChangeAuctionStatus) {
+    return await this.auctionService.changeAuctionStatus(req.user.sub, changeAuctionStatusBody);
   }
 }

--- a/src/modules/auction/entrypoints/dto.ts
+++ b/src/modules/auction/entrypoints/dto.ts
@@ -676,3 +676,28 @@ export class PlaceBidBody {
   @IsNumber()
   amount: number;
 }
+
+export class ChangeAuctionStatus {
+  @ApiProperty({
+    example: 1,
+    description: 'The id of the auction that the status will be changing',
+  })
+  @IsNumber()
+  auctionId: number;
+
+  @ApiProperty({
+    example: [
+      { name: 'canceled', value: true },
+      { name: 'depositing', value: false },
+    ],
+    description: 'Array of statuses that need to be changed',
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  statuses: StatusChange[];
+}
+
+class StatusChange {
+  name: string;
+  value: boolean;
+}

--- a/src/modules/auction/service-layer/auction.service.ts
+++ b/src/modules/auction/service-layer/auction.service.ts
@@ -14,6 +14,7 @@ import {
   UpdateRewardTierBody,
   DepositNftsBody,
   PlaceBidBody,
+  ChangeAuctionStatus,
 } from '../entrypoints/dto';
 import { Nft } from 'src/modules/nft/domain/nft.entity';
 import { AuctionNotFoundException } from './exceptions/AuctionNotFoundException';
@@ -920,5 +921,20 @@ export class AuctionService {
     if (limit === 0 || page === 0) return;
 
     query.limit(limit).offset((page - 1) * limit);
+  }
+
+  public async changeAuctionStatus(userId: number, changeAuctionStatusBody: ChangeAuctionStatus) {
+    //TODO: This is a temporary endpoint until the scraper functionality is finished
+    let auction = await this.validateAuctionPermissions(userId, changeAuctionStatusBody.auctionId);
+
+    changeAuctionStatusBody.statuses.forEach((status) => {
+      auction[status.name] = status.value;
+    });
+
+    auction = await this.auctionRepository.save(auction);
+
+    return {
+      auction,
+    };
   }
 }


### PR DESCRIPTION
Adding a temporary endpoint that enables changing auctions statuses. This is to enable FE work on validating and invalidating certain actions based on the current auction status.

[Issue in FE repo](https://github.com/UniverseXYZ/UniverseApp-Frontend/issues/911)

cc: @taskudis @boris-bonin 