### PR TITLE
Change response of my collections

### DIFF
--- a/src/modules/nft/entrypoints/nft.controller.ts
+++ b/src/modules/nft/entrypoints/nft.controller.ts
@@ -254,7 +254,7 @@ export class NftController {
     if (params.mintable === 'true') {
       return await this.nftService.getMyMintableCollections(req.user.sub);
     }
-    return await this.nftService.getMyOwnedCollections(req.user.sub);
+    return await this.nftService.getMyNftsCollections(req.user.sub);
   }
 
   @Delete('saved-nfts/:id')


### PR DESCRIPTION
Change response of my collections to return collections of nfts that you own.

Context: 
From yesterday's feedback changes it was request that we not only created collections but also all collections of nfts that you own and also to be able to filter using them.

Changes:
The purpose of the my nft collections service is to return collections of nfts that you own. It will be used on my-nfts page to show collections and be able to filter.

The owned collections service will work as normal and return only collections that you can mint nfts in(universe core collection + any unverse collections that the user has minted)