### PR TITLE
improve(my-nfts): Pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug 0.0.0.0:9229 --watch",
     "start:prod": "node dist/main",
+    "start:docker": "docker-compose -f docker-compose.external.yml up",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/src/modules/nft/entrypoints/dto.ts
+++ b/src/modules/nft/entrypoints/dto.ts
@@ -457,6 +457,20 @@ export class GetUserNftsQueryParams {
     example: '1',
   })
   limit: number;
+
+  @IsOptional()
+  @ApiProperty({
+    description: 'The collection ids to filter by',
+    example: '12,3',
+  })
+  collections: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({
+    description: 'NFT name',
+  })
+  name: string;
 }
 
 export class GetSavedNftsParams {
@@ -709,13 +723,10 @@ export class GetMyNftsPageParams {
   limit: number;
 
   @IsOptional()
-  // @IsArray()
-  // @IsString({ each: true })
-  // @Type(() => String)
-  // @ApiProperty({
-  //   description: 'Collection addresses',
-  // })
-  // @Transform(({ value }) => value.split(','))
+  @ApiProperty({
+    description: 'The collection ids to filter by',
+    example: '12,3',
+  })
   collections: string;
 
   @IsOptional()

--- a/src/modules/nft/entrypoints/nft.controller.ts
+++ b/src/modules/nft/entrypoints/nft.controller.ts
@@ -239,7 +239,7 @@ export class NftController {
   @ApiOperation({ summary: 'Get user NFTs' })
   @ApiResponse({ type: GetUserNftsResponse, status: 200, isArray: true })
   async getUserNfts(@Param() params: GetUserNftsParams, @Query() query: GetUserNftsQueryParams) {
-    return await this.nftService.getUserNfts(params.username, query.limit, query.offset);
+    return await this.nftService.getUserNfts(params.username, query.limit, query.offset, query.name, query.collections);
   }
 
   // @Get('pages/user-profile/:address/collections')
@@ -267,9 +267,16 @@ export class NftController {
   @ApiOperation({ summary: 'Get the list of all my collections' })
   async getMyCollections(@Req() req, @Query() params: GetMyCollectionsParams) {
     if (params.mintable === 'true') {
-      return await this.nftService.getMyMintableCollections(req.user.sub, params.limit, params.offset);
+      return await this.nftService.getMyMintableCollections(req.user.sub);
     }
-    return await this.nftService.getMyNftsCollections(req.user.sub, params.limit, params.offset);
+    return await this.nftService.getMyNftsCollections(req.user.address);
+  }
+
+  @Get('nfts/collections/:address')
+  @ApiTags('nfts')
+  @ApiOperation({ summary: 'Get the list of collections for a specific user' })
+  async getUserCollections(@Req() req, @Param() params: { address: string }) {
+    return await this.nftService.getMyNftsCollections(params.address);
   }
 
   @Get('pages/my-nfts/collections')
@@ -317,8 +324,8 @@ export class NftController {
   @ApiTags('nfts')
   @ApiOperation({ summary: 'Get data to populate the pending section of My Collections page' })
   @ApiBearerAuth()
-  async getMyCollectionsPending(@Req() req, @Query() params: GetMyCollectionsPendingParams) {
-    return this.nftService.getMyCollectionsPendingPage(req.user.sub, params.limit, params.offset);
+  async getMyCollectionsPending(@Req() req) {
+    return this.nftService.getMyCollectionsPendingPage(req.user.sub);
   }
 
   @Get('pages/my-collections/pending/count')
@@ -335,8 +342,8 @@ export class NftController {
   @ApiTags('nfts')
   @ApiOperation({ summary: 'Pending NFTs for My NFTs page' })
   @ApiBearerAuth()
-  async getMyNftsPendingPage(@Req() req, @Query() params: GetMyNftsPendingParams) {
-    return this.nftService.getMyNftsPendingPage(req.user.sub, params.limit, params.offset);
+  async getMyNftsPendingPage(@Req() req) {
+    return this.nftService.getMyNftsPendingPage(req.user.sub);
   }
 
   @Get('pages/my-nfts/pending/count')


### PR DESCRIPTION
Query params limit and offset added to:
- saved-nfts
- nfts/my-nfts
- nfts/collections/my-collections
- pages/my-collections/pending
- pages/my-nfts/pending
- pages/user-profile/:username/nfts
- pages/my-nfts

New endpoint 'pages/my-nfts/summary'
- Authorization header
- response: 
   {
    "nfts": 11,
    "collections": 3,
    "savedNfts": 10
   }

For FE: 
- The new paginated pages have to be updated with limit and offset.
- The numbers in brackets for the tabs should be from the new endpoint.

//TODO for BE: implement search logic for where its needed