### PR TITLE
mimetype added before uploading to S3

### DIFF
--- a/src/modules/auction/service-layer/auction.service.ts
+++ b/src/modules/auction/service-layer/auction.service.ts
@@ -255,7 +255,7 @@ export class AuctionService {
     let s3Result: UploadResult;
 
     if (image) {
-      s3Result = await this.s3Service.uploadDocument(image.path, image.filename);
+      s3Result = await this.s3Service.uploadDocument(image.path, image.filename, image.mimetype);
       rewardTier.imageUrl = s3Result.url;
       await this.rewardTierRepository.save(rewardTier);
       await this.fileSystemService.removeFile(image.path);
@@ -415,6 +415,7 @@ export class AuctionService {
       const uploadResult = await this.s3Service.uploadDocument(
         promoImageFile.path,
         `auctions/${promoImageFile.filename}`,
+        promoImageFile.mimetype,
       );
       auction.promoImageUrl = uploadResult.url;
       await this.fileSystemService.removeFile(promoImageFile.path);
@@ -424,6 +425,7 @@ export class AuctionService {
       const uploadResult = await this.s3Service.uploadDocument(
         backgroundImageFile.path,
         `auctions/${backgroundImageFile.filename}`,
+        backgroundImageFile.mimetype,
       );
       auction.backgroundImageUrl = uploadResult.url;
       await this.fileSystemService.removeFile(backgroundImageFile.path);

--- a/src/modules/file-storage/s3.service.ts
+++ b/src/modules/file-storage/s3.service.ts
@@ -18,7 +18,7 @@ export class S3Service {
     return key && `${this.config.values.aws.s3BaseUrl}/${key}`;
   }
 
-  public uploadDocument(sourcePath: string, bucketPath: string) {
+  public uploadDocument(sourcePath: string, bucketPath: string, mimeType?: string) {
     return new Promise<UploadResult>((resolve, reject) => {
       const stream = fs.createReadStream(sourcePath);
       this.client.upload(
@@ -26,7 +26,7 @@ export class S3Service {
           Bucket: this.config.values.aws.bucketName,
           Key: bucketPath,
           Body: stream,
-          ContentType: 'image/jpeg',
+          ContentType: mimeType || 'application/octet-stream',
         },
         (error, data) => {
           if (error) {

--- a/src/modules/nft/service_layer/nft.service.ts
+++ b/src/modules/nft/service_layer/nft.service.ts
@@ -163,7 +163,7 @@ export class NftService {
 
     this.logger.log('Starting to upload files to AWS');
     await Promise.all([
-      this.s3Service.uploadDocument(file.path, `${file.filename}`),
+      this.s3Service.uploadDocument(file.path, `${file.filename}`, file.mimetype),
       ...uniqueFiles.map((fileItem) => this.s3Service.uploadDocument(fileItem.path, `${fileItem.fullFilename()}`)),
     ]);
     this.logger.log('Uploaded files to bucket successfully');
@@ -287,7 +287,7 @@ export class NftService {
 
     let s3Result: UploadResult;
     if (file) {
-      s3Result = await this.s3Service.uploadDocument(file.path, file.filename);
+      s3Result = await this.s3Service.uploadDocument(file.path, file.filename, file.mimetype);
     }
 
     let mintingCollection = this.mintingCollectionRepository.create({
@@ -339,7 +339,7 @@ export class NftService {
     let s3Result: UploadResult;
 
     if (file) {
-      s3Result = await this.s3Service.uploadDocument(file.path, file.filename);
+      s3Result = await this.s3Service.uploadDocument(file.path, file.filename, file.mimetype);
       collection.coverUrl = s3Result.url;
       await this.nftCollectionRepository.save(collection);
     }
@@ -353,7 +353,7 @@ export class NftService {
     let s3Result: UploadResult;
 
     if (file) {
-      s3Result = await this.s3Service.uploadDocument(file.path, file.filename);
+      s3Result = await this.s3Service.uploadDocument(file.path, file.filename, file.mimetype);
       collection.bannerUrl = s3Result.url;
       await this.nftCollectionRepository.save(collection);
     }

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -67,7 +67,7 @@ export class UsersService {
         throw new Error('User not found');
       }
 
-      const result = await this.s3Service.uploadDocument(`${file.path}`, `profiles/${file.filename}`);
+      const result = await this.s3Service.uploadDocument(`${file.path}`, `profiles/${file.filename}`, file.mimetype);
 
       userDb.profileImageName = result.key;
       await this.usersRepository.save(userDb);
@@ -93,7 +93,7 @@ export class UsersService {
         throw new Error('User not found');
       }
 
-      const result = await this.s3Service.uploadDocument(`${file.path}`, `logos/${file.filename}`);
+      const result = await this.s3Service.uploadDocument(`${file.path}`, `logos/${file.filename}`, file.mimetype);
       userDb.logoImageName = result.key;
       await this.usersRepository.save(userDb);
 


### PR DESCRIPTION
Currently we have an issue in which when you send a link to a user profile page in iMessage the metadata (image, description) is not displayed. After digging into the issue it seems that all the resources (images, videos) are uploaded without explicitly providing a MIME type. This PR is for changing this behaviour and providing the MIME type before uploading to S3.
However this is only the first part of the fix. All images that are currently uploaded on S3 should have the correct MIME type. It can be done via the S3 console. Here is a link from a SO discussion regarding the topic: https://stackoverflow.com/questions/19100858/how-do-you-change-the-mime-on-amazon-s3